### PR TITLE
Configure plyr object to disallow click to play on video wrapper

### DIFF
--- a/custom.php
+++ b/custom.php
@@ -52,7 +52,9 @@ function display_video($item='item') {
                 </div>
                 <script async defer>
                     document.addEventListener('DOMContentLoaded', () => {
-                      const player = new Plyr('#jsplayer-<?php echo $file->id ?>');
+                      const player = new Plyr('#jsplayer-<?php echo $file->id ?>', {
+                        clickToPlay: false,
+                      });
                       // Bind event listener
                       function on(selector, type, callback) {
                         document.querySelector(selector).addEventListener(type, callback, false);


### PR DESCRIPTION
This addresses a mobile issue where the user could inadvertently play a video while scrolling down the page.